### PR TITLE
Add DailyBites Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ ChromeExtension-DailyBites is a lightweight Chrome extension that helps you stay
 
 Perfect for developers, researchers, and tech enthusiasts who want a daily dose of insights without extra browsing effort.
 
+## Installation
+
+1. Clone or download this repository.
+2. Open `chrome://extensions/` in Chrome and enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+4. Click the DailyBites extension icon to see the latest links.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "DailyBites",
+  "version": "1.0",
+  "description": "Displays top 3 Hacker News links and top 2 Hugging Face papers.",
+  "action": {
+    "default_title": "DailyBites",
+    "default_popup": "popup.html"
+  },
+  "host_permissions": [
+    "https://hacker-news.firebaseio.com/*",
+    "https://huggingface.co/*"
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>DailyBites</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 320px; padding: 10px; }
+    h2 { font-size: 16px; margin: 10px 0 5px; }
+    ul { list-style: none; padding-left: 0; }
+    li { margin-bottom: 8px; }
+    a { text-decoration: none; color: #0366d6; }
+  </style>
+</head>
+<body>
+  <h2>Hacker News</h2>
+  <ul id="hn-list"><li>Loading...</li></ul>
+  <h2>Hugging Face Papers</h2>
+  <ul id="hf-list"><li>Loading...</li></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,49 @@
+async function loadHackerNews() {
+  const hnList = document.getElementById('hn-list');
+  hnList.innerHTML = '<li>Loading...</li>';
+  try {
+    const ids = await fetch('https://hacker-news.firebaseio.com/v0/topstories.json')
+      .then(r => r.json());
+    hnList.innerHTML = '';
+    for (const id of ids.slice(0, 3)) {
+      const story = await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`)
+        .then(r => r.json());
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = story.url || `https://news.ycombinator.com/item?id=${id}`;
+      a.textContent = story.title;
+      a.target = '_blank';
+      li.appendChild(a);
+      hnList.appendChild(li);
+    }
+  } catch (e) {
+    hnList.innerHTML = '<li>Error loading stories</li>';
+  }
+}
+
+async function loadHuggingFace() {
+  const hfList = document.getElementById('hf-list');
+  hfList.innerHTML = '<li>Loading...</li>';
+  try {
+    const res = await fetch('https://huggingface.co/api/papers?limit=2');
+    const json = await res.json();
+    const papers = Array.isArray(json) ? json : (json.papers || []);
+    hfList.innerHTML = '';
+    papers.slice(0, 2).forEach(paper => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = paper.url || paper.link || `https://huggingface.co/papers/${paper.id || paper.paperId || ''}`;
+      a.textContent = paper.title || paper.paper_title || 'Untitled';
+      a.target = '_blank';
+      li.appendChild(a);
+      hfList.appendChild(li);
+    });
+  } catch (e) {
+    hfList.innerHTML = '<li>Error loading papers</li>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadHackerNews();
+  loadHuggingFace();
+});


### PR DESCRIPTION
## Summary
- add manifest and popup for DailyBites Chrome extension
- fetch top 3 Hacker News stories and top 2 Hugging Face papers
- document installation steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5f92234c83338a0d4c5273dfa11c