### PR TITLE
feat: add glassy header and table layout

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -6,17 +6,30 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <section>
-    <h2>Hacker News</h2>
-    <ul id="hn-list"><li>Loading...</li></ul>
-    <div class="center">
-      <a href="https://news.ycombinator.com/" target="_blank" class="btn">View All Stories</a>
-    </div>
-  </section>
-  <section>
-    <h2>Hugging Face Papers</h2>
-    <ul id="hf-list"><li>Loading...</li></ul>
-  </section>
+  <header>
+    <h1>DailyBites</h1>
+  </header>
+  <table class="content-table">
+    <thead>
+      <tr>
+        <th>Hacker News</th>
+        <th>Hugging Face Papers</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <ul id="hn-list"><li>Loading...</li></ul>
+          <div class="center">
+            <a href="https://news.ycombinator.com/" target="_blank" class="btn">View All Stories</a>
+          </div>
+        </td>
+        <td>
+          <ul id="hf-list"><li>Loading...</li></ul>
+        </td>
+      </tr>
+    </tbody>
+  </table>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,46 +1,78 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
 body {
-  font-family: 'Segoe UI', Tahoma, sans-serif;
-  width: 340px;
+  font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+  width: 360px;
   margin: 0;
-  padding: 0;
-  background-color: #f5f5f5;
+  padding: 16px;
+  background: linear-gradient(135deg, #74ebd5 0%, #ACB6E5 100%);
+  color: #ffffff;
 }
-section {
-  background: #ffffff;
+
+header {
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+header h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.content-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 12px;
+}
+
+.content-table th,
+.content-table td {
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  margin: 12px;
-  padding: 12px 16px;
+  backdrop-filter: blur(10px);
+  padding: 12px;
+  vertical-align: top;
 }
-h2 {
-  font-size: 16px;
-  margin: 0 0 8px 0;
-  color: #333333;
+
+.content-table th {
+  font-size: 14px;
+  color: #ffffff;
+  font-weight: 600;
 }
+
 ul {
   list-style: none;
   padding-left: 0;
   margin: 0;
 }
+
 li {
   margin-bottom: 6px;
 }
+
 a {
   text-decoration: none;
   color: #1a73e8;
 }
+
 .btn {
   display: inline-block;
-  background: #ff6600;
+  background: rgba(255, 102, 0, 0.8);
   color: #ffffff;
   padding: 8px 16px;
   border-radius: 4px;
   font-size: 12px;
   font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(10px);
 }
+
 .btn:hover {
-  background: #e65c00;
+  background: rgba(230, 92, 0, 0.8);
 }
+
 .center {
   text-align: center;
   margin-top: 8px;


### PR DESCRIPTION
## Summary
- add top header and table-based layout to show Hacker News and Hugging Face content side-by-side
- revamp styling with Poppins font, gradient background, and glassy cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc782455c883339089d70663f6e357