### PR TITLE
Revamp layout with tables and add PDF links

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -9,27 +9,27 @@
   <header>
     <h1>DailyBites</h1>
   </header>
-  <table class="content-table">
-    <thead>
-      <tr>
-        <th>Hacker News</th>
-        <th>Hugging Face Papers</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <ul id="hn-list"><li>Loading...</li></ul>
-          <div class="center">
-            <a href="https://news.ycombinator.com/" target="_blank" class="btn">View All Stories</a>
-          </div>
-        </td>
-        <td>
-          <ul id="hf-list"><li>Loading...</li></ul>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="container">
+    <div class="box">
+      <h2>Hacker News</h2>
+      <table class="items">
+        <tbody id="hn-list">
+          <tr><td>Loading...</td></tr>
+        </tbody>
+      </table>
+      <div class="center">
+        <a href="https://news.ycombinator.com/" target="_blank" class="btn">View All Stories</a>
+      </div>
+    </div>
+    <div class="box">
+      <h2>Hugging Face Papers</h2>
+      <table class="items">
+        <tbody id="hf-list">
+          <tr><td>Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -20,36 +20,40 @@ header h1 {
   margin: 0;
 }
 
-.content-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 12px;
+
+.container {
+  display: flex;
+  gap: 12px;
 }
 
-.content-table th,
-.content-table td {
+.box {
+  flex: 1;
   background: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 8px;
   backdrop-filter: blur(10px);
   padding: 12px;
-  vertical-align: top;
 }
 
-.content-table th {
+.box h2 {
   font-size: 14px;
   color: #ffffff;
   font-weight: 600;
+  margin-top: 0;
 }
 
-ul {
-  list-style: none;
-  padding-left: 0;
-  margin: 0;
+.items {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-li {
-  margin-bottom: 6px;
+.items td {
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.items tr:last-child td {
+  border-bottom: none;
 }
 
 a {


### PR DESCRIPTION
## Summary
- Replace popup layout with dual-column boxes using tables for content rows
- Add PDF download links by scraping Hugging Face paper pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a9225b48333a853dc5087647fe8