### PR TITLE
Stack boxes vertically and show both Hugging Face papers

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -64,10 +64,11 @@ async function loadHuggingFace() {
       if (count >= 2) break;
 
       const title = link.textContent.trim();
-      if (title && title.length > 10) {
-        const tr = document.createElement('tr');
-        const titleTd = document.createElement('td');
-        const pdfTd = document.createElement('td');
+      if (!title) continue;
+
+      const tr = document.createElement('tr');
+      const titleTd = document.createElement('td');
+      const pdfTd = document.createElement('td');
 
         const a = document.createElement('a');
         const href = link.getAttribute('href');
@@ -107,11 +108,10 @@ async function loadHuggingFace() {
           pdfTd.textContent = 'N/A';
         }
 
-        tr.appendChild(titleTd);
-        tr.appendChild(pdfTd);
-        hfList.appendChild(tr);
-        count++;
-      }
+      tr.appendChild(titleTd);
+      tr.appendChild(pdfTd);
+      hfList.appendChild(tr);
+      count++;
     }
     
     // If still no papers found, show a fallback with a link to the papers page

--- a/style.css
+++ b/style.css
@@ -23,11 +23,11 @@ header h1 {
 
 .container {
   display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 
 .box {
-  flex: 1;
   background: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- Stack extension sections vertically for a top-bottom layout.
- Fix Hugging Face scraper to collect up to two paper links consistently.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c274ba08333a1bd281028d49bfb